### PR TITLE
Store environmental data as float arrays

### DIFF
--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -119,7 +119,6 @@ export function _mapCellToDense(z, x, y){
 
 export async function _applySparseIntoDense(z, arr){
   const F=this.schema.fieldNames.length;
-  const applyFields=this.schema.fieldNames;
   for (const key in this.dataTable){
     const parts=key.split(',');
     const zi=Number(parts[2]||-1);
@@ -130,8 +129,7 @@ export async function _applySparseIntoDense(z, arr){
     const base=this._denseIdx(F, bx, by, 0);
     const src=this.dataTable[key];
     for (let fi=0; fi<F; fi++){
-      const name=applyFields[fi];
-      const v=src[name] || 0;
+      const v=src[fi] || 0;
       if (v!==0) arr[base+fi]=v;
     }
   }

--- a/SDFGridPersistence.js
+++ b/SDFGridPersistence.js
@@ -25,7 +25,9 @@ export function saveBlobs(){
             d:(p.d!=null?p.d:1),
             t:(p.t!=null?p.t:0)
           })) : [];
-          sparse.push({ x,y,z, particles, data });
+          const entry={ x,y,z, particles };
+          if (data) entry.data=Array.from(data);
+          sparse.push(entry);
         }
       }
     }
@@ -70,9 +72,20 @@ export function applyBlobs(blobs){
           time:p.t!=null?p.t:0
         }));
       }
-      if (data && typeof data==='object'){
-        const key=`${x},${y},${z}`; this.dataTable[key] = { ...data };
-        if (data.O2) this._maxO2 = Math.max(this._maxO2, data.O2);
+      if (data){
+        const arr=new Float32Array(this.schema.fieldNames.length);
+        if (Array.isArray(data)){
+          for(let i=0;i<Math.min(data.length, arr.length); i++) arr[i]=data[i]||0;
+        } else if (typeof data==='object'){
+          for (const [name,val] of Object.entries(data)){
+            const fi=this.schema.index.get(name);
+            if (fi!=null) arr[fi]=val;
+          }
+        }
+        const key=`${x},${y},${z}`;
+        this.dataTable[key] = arr;
+        const o2Idx=this.schema.index.get('O2');
+        if (o2Idx!=null && arr[o2Idx]) this._maxO2 = Math.max(this._maxO2, arr[o2Idx]);
       }
     }
   });


### PR DESCRIPTION
## Summary
- store per-cell environmental data as `Float32Array` values
- persist overlay data as arrays and restore it when loading blobs
- update dense-layer construction and dispersion to use array-based cell values

## Testing
- `node --check SDFGridState.js`
- `node --check SDFGridPersistence.js`
- `node --check SDFGridLayers.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c65f379d7c832dac6b9a0143b39425