### PR TITLE
Enable serialized env expressions for flexible quadrant templates

### DIFF
--- a/SDFGridEnvExpressions.js
+++ b/SDFGridEnvExpressions.js
@@ -1,0 +1,16 @@
+export function serializeEnvHash(env){
+  return JSON.stringify(env || {});
+}
+
+export function parseEnvExpression(expr){
+  if (typeof expr === 'string'){
+    try { return JSON.parse(expr); } catch { return {}; }
+  }
+  if (expr && typeof expr === 'object') return expr;
+  return {};
+}
+
+export function envExpressionFromModule(mod){
+  const obj = mod?.default ?? mod;
+  return serializeEnvHash(obj);
+}

--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -5,11 +5,11 @@ import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js
 
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
-  if (!this._db) return createSparseQuadrants(count, this.envTemplate || {});
+  if (!this._db) return createSparseQuadrants(count, this.envExpressions || []);
   const key=`sid:${this.schema.id}`;
   let tmpl=await idbGet(this._db, STORE_BASEZ, key);
   if (!tmpl){
-    tmpl=createSparseQuadrants(count, this.envTemplate || {});
+    tmpl=createSparseQuadrants(count, this.envExpressions || []);
     await idbPut(this._db, STORE_BASEZ, key, tmpl);
   }
   return tmpl;

--- a/SDFGridQuadrants.js
+++ b/SDFGridQuadrants.js
@@ -1,4 +1,5 @@
 import { DENSE_W, DENSE_H, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
+import { parseEnvExpression } from './SDFGridEnvExpressions.js';
 
 // Quantize environment variables using the Pareto principle (top 20% retained)
 export function quantizePareto(env){
@@ -14,11 +15,17 @@ export function quantizePareto(env){
   return out;
 }
 
-// Create a sparse quadrant template, quantizing each quadrant's environment variables
-export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envTemplate = {}){
+// Create sparse quadrants from serialized environment expressions
+// Each expression resolves to an object whose keys become the quadrant variables
+// with zero as the default value. Expressions can differ per quadrant.
+export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envExprs = []){
   const quads = [];
   for (let i=0; i<count; i++){
-    quads.push(quantizePareto(envTemplate));
+    const expr = envExprs[i] ?? envExprs[0] ?? {};
+    const tmpl = parseEnvExpression(expr);
+    const q = {};
+    for (const k of Object.keys(tmpl)) q[k] = 0;
+    quads.push(q);
   }
   return { quadrants: quads };
 }


### PR DESCRIPTION
## Summary
- Introduce `SDFGridEnvExpressions` utility to serialize and parse environment variable definitions
- Build sparse quadrants from per-quadrant serialized expressions
- Initialize `SDFGrid` with env modules to derive variable sets dynamically

## Testing
- `node --check SDFGridQuadrants.js`
- `node --check SDFGridCore.js`
- `node --check SDFGridLayers.js`
- `node --check SDFGridEnvExpressions.js`


------
https://chatgpt.com/codex/tasks/task_e_68c776a34bf4832db29489bf2ce8602e