### PR TITLE
Enable serialized env expressions for flexible quadrant templates

### DIFF
--- a/SDFGridEnvExpressions.js
+++ b/SDFGridEnvExpressions.js
@@ -1,0 +1,16 @@
+export function serializeEnvHash(env){
+  return JSON.stringify(env || {});
+}
+
+export function parseEnvExpression(expr){
+  if (typeof expr === 'string'){
+    try { return JSON.parse(expr); } catch { return {}; }
+  }
+  if (expr && typeof expr === 'object') return expr;
+  return {};
+}
+
+export function envExpressionFromModule(mod){
+  const obj = mod?.default ?? mod;
+  return serializeEnvHash(obj);
+}

--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -5,11 +5,11 @@ import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js
 
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
-  if (!this._db) return createSparseQuadrants(count, this.envTemplate || {});
+  if (!this._db) return createSparseQuadrants(count, this.envExpressions || []);
   const key=`sid:${this.schema.id}`;
   let tmpl=await idbGet(this._db, STORE_BASEZ, key);
   if (!tmpl){
-    tmpl=createSparseQuadrants(count, this.envTemplate || {});
+    tmpl=createSparseQuadrants(count, this.envExpressions || []);
     await idbPut(this._db, STORE_BASEZ, key, tmpl);
   }
   return tmpl;

--- a/SDFGridQuadrants.js
+++ b/SDFGridQuadrants.js
@@ -1,4 +1,5 @@
 import { DENSE_W, DENSE_H, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
+import { parseEnvExpression } from './SDFGridEnvExpressions.js';
 
 // Quantize environment variables using the Pareto principle (top 20% retained)
 export function quantizePareto(env){
@@ -14,11 +15,17 @@ export function quantizePareto(env){
   return out;
 }
 
-// Create a sparse quadrant template, quantizing each quadrant's environment variables
-export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envTemplate = {}){
+// Create sparse quadrants from serialized environment expressions
+// Each expression resolves to an object whose keys become the quadrant variables
+// with zero as the default value. Expressions can differ per quadrant.
+export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envExprs = []){
   const quads = [];
   for (let i=0; i<count; i++){
-    quads.push(quantizePareto(envTemplate));
+    const expr = envExprs[i] ?? envExprs[0] ?? {};
+    const tmpl = parseEnvExpression(expr);
+    const q = {};
+    for (const k of Object.keys(tmpl)) q[k] = 0;
+    quads.push(q);
   }
   return { quadrants: quads };
 }
@@ -27,19 +34,34 @@ export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envTemplat
 export function denseFromQuadrants(template, schema){
   const F = schema.fieldNames.length;
   const arr = new Float32Array(DENSE_W * DENSE_H * F);
-  if (!template?.quadrants || !template.quadrants.length) return arr;
-  const totalPixels = DENSE_W * DENSE_H;
-  const qCount = template.quadrants.length;
-  const areaPerQ = Math.ceil(totalPixels / qCount);
-  let pix = 0;
-  for (const quad of template.quadrants){
+  const quads = template?.quadrants || [];
+  const qCount = quads.length;
+  if (!qCount) return arr;
+
+  // Lay out quadrants across the 1024×1024 layer in a near-square grid
+  const cols = Math.ceil(Math.sqrt(qCount));
+  const rows = Math.ceil(qCount / cols);
+  const qW = Math.ceil(DENSE_W / cols);
+  const qH = Math.ceil(DENSE_H / rows);
+
+  for (let i=0; i<qCount; i++){
+    const quad = quads[i];
     const entries = Object.entries(quad);
-    const end = Math.min(pix + areaPerQ, totalPixels);
-    for (; pix < end; pix++){
-      const base = pix * F;
-      for (const [name, val] of entries){
-        const fi = schema.index.get(name);
-        if (fi != null) arr[base + fi] = val;
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const xStart = col * qW;
+    const yStart = row * qH;
+    const xEnd = Math.min(xStart + qW, DENSE_W);
+    const yEnd = Math.min(yStart + qH, DENSE_H);
+
+    for (let y=yStart; y<yEnd; y++){
+      const rowBase = y * DENSE_W * F;
+      for (let x=xStart; x<xEnd; x++){
+        const base = rowBase + x * F;
+        for (const [name, val] of entries){
+          const fi = schema.index.get(name);
+          if (fi != null) arr[base + fi] = val;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Introduce `SDFGridEnvExpressions` utility to serialize and parse environment variable definitions
- Build sparse quadrants from per-quadrant serialized expressions
- Initialize `SDFGrid` with env modules to derive variable sets dynamically
- Map `base_zero` quadrants across the 1024×1024 overlay grid when seeding dense layers

## Testing
- `node --check SDFGridQuadrants.js`
- `node --check SDFGridCore.js`
- `node --check SDFGridLayers.js`
- `node --check SDFGridEnvExpressions.js`


------
https://chatgpt.com/codex/tasks/task_e_68c776a34bf4832db29489bf2ce8602e