### PR TITLE
Enable serialized env expressions for flexible quadrant templates

### DIFF
--- a/SDFGridEnvExpressions.js
+++ b/SDFGridEnvExpressions.js
@@ -1,0 +1,16 @@
+export function serializeEnvHash(env){
+  return JSON.stringify(env || {});
+}
+
+export function parseEnvExpression(expr){
+  if (typeof expr === 'string'){
+    try { return JSON.parse(expr); } catch { return {}; }
+  }
+  if (expr && typeof expr === 'object') return expr;
+  return {};
+}
+
+export function envExpressionFromModule(mod){
+  const obj = mod?.default ?? mod;
+  return serializeEnvHash(obj);
+}

--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -1,15 +1,31 @@
 import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import { arraysEqual } from './SDFGridUtil.js';
 import { idbGet, idbPut } from './SDFGridStorage.js';
-import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js';
+import { createSparseQuadrants } from './SDFGridQuadrants.js';
+
+function quadrantLayout(count){
+  const cols=Math.ceil(Math.sqrt(count));
+  const rows=Math.ceil(count/cols);
+  const qW=Math.ceil(DENSE_W/cols);
+  const qH=Math.ceil(DENSE_H/rows);
+  return {cols,rows,qW,qH};
+}
+
+function quadrantBounds(layout,i){
+  const col=i%layout.cols; const row=Math.floor(i/layout.cols);
+  const xStart=col*layout.qW; const yStart=row*layout.qH;
+  const xEnd=Math.min(xStart+layout.qW, DENSE_W);
+  const yEnd=Math.min(yStart+layout.qH, DENSE_H);
+  return {xStart,yStart,xEnd,yEnd,w:xEnd-xStart,h:yEnd-yStart};
+}
 
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
-  if (!this._db) return createSparseQuadrants(count, this.envTemplate || {});
+  if (!this._db) return createSparseQuadrants(count, this.envExpressions || []);
   const key=`sid:${this.schema.id}`;
   let tmpl=await idbGet(this._db, STORE_BASEZ, key);
   if (!tmpl){
-    tmpl=createSparseQuadrants(count, this.envTemplate || {});
+    tmpl=createSparseQuadrants(count, this.envExpressions || []);
     await idbPut(this._db, STORE_BASEZ, key, tmpl);
   }
   return tmpl;
@@ -52,56 +68,101 @@ export function _denseIdx(F,xPix,yPix,fi){
   return ((yPix*DENSE_W)+xPix)*F + fi;
 }
 
+export async function _ensureQuadrantLayer(z,qIdx){
+  const key=`${z}:${qIdx}`;
+  if (this._quadrantCache.has(key)) return this._quadrantCache.get(key);
+
+  const tmpl=await this._ensureZeroTemplate();
+  const qCount=tmpl.quadrants.length;
+  const layout=quadrantLayout(qCount);
+  const bounds=quadrantBounds(layout,qIdx);
+  const F=this.schema.fieldNames.length;
+  let arr;
+
+  if (!this._db){
+    arr=new Float32Array(bounds.w*bounds.h*F);
+  } else {
+    const lmeta=await idbGet(this._db, STORE_LMETA, z|0);
+    const buf=await idbGet(this._db, STORE_LAYER, key);
+    if (buf){
+      const curSid=lmeta?.sid|0;
+      const curList=lmeta?.fields||[];
+      if (curSid===this.schema.id && arraysEqual(curList,this.schema.fieldNames)){
+        arr=new Float32Array(buf);
+      } else {
+        const old=new Float32Array(buf);
+        const Fold=curList.length; const Fnew=this.schema.fieldNames.length;
+        arr=new Float32Array(bounds.w*bounds.h*Fnew);
+        const oldIdx=new Map(curList.map((n,i)=>[n,i]));
+        for(let y=0;y<bounds.h;y++){
+          const rowOld=y*bounds.w*Fold; const rowNew=y*bounds.w*Fnew;
+          for(let x=0;x<bounds.w;x++){
+            const baseOld=rowOld+x*Fold; const baseNew=rowNew+x*Fnew;
+            for (const [name,fiNew] of this.schema.index){
+              const fiOld=oldIdx.get(name); if (fiOld!=null) arr[baseNew+fiNew]=old[baseOld+fiOld];
+            }
+          }
+        }
+        await idbPut(this._db, STORE_LAYER, key, arr.buffer);
+        await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
+      }
+    } else {
+      arr=new Float32Array(bounds.w*bounds.h*F);
+      const quad=tmpl.quadrants[qIdx]||{};
+      const entries=Object.entries(quad);
+      for(let y=0;y<bounds.h;y++){
+        const row=y*bounds.w*F;
+        for(let x=0;x<bounds.w;x++){
+          const base=row+x*F;
+          for (const [name,val] of entries){
+            const fi=this.schema.index.get(name); if (fi!=null) arr[base+fi]=val;
+          }
+        }
+      }
+      for (const k in this.dataTable){
+        const parts=k.split(',');
+        const zi=Number(parts[2]||-1); if (zi!==(z|0)) continue;
+        const cx=Number(parts[0]), cy=Number(parts[1]);
+        if (cx<0||cy<0||cx>=this.state.cellsX||cy>=this.state.cellsY) continue;
+        const { bx, by } = this._mapCellToDense(z,cx,cy);
+        if (bx<bounds.xStart||bx>=bounds.xEnd||by<bounds.yStart||by>=bounds.yEnd) continue;
+        const lx=bx-bounds.xStart, ly=by-bounds.yStart;
+        const base=(ly*bounds.w+lx)*F; const src=this.dataTable[k];
+        for (const [name,v] of Object.entries(src)){
+          const fi=this.schema.index.get(name); if (fi!=null) arr[base+fi]=v||0;
+        }
+      }
+      await idbPut(this._db, STORE_LAYER, key, arr.buffer);
+      await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
+    }
+  }
+
+  this._quadrantCache.set(key,arr);
+  return arr;
+}
+
 export async function _ensureDenseLayer(z){
   const key=z|0;
   if (this._layerCache.has(key)) return this._layerCache.get(key);
 
-  const targetSchema=this.schema;
-  if (!this._db){
-    const arr=new Float32Array(DENSE_W*DENSE_H*targetSchema.fieldNames.length);
-    this._layerCache.set(key,arr); return arr;
-  }
+  const tmpl=await this._ensureZeroTemplate();
+  const qCount=tmpl.quadrants.length;
+  const layout=quadrantLayout(qCount);
+  const F=this.schema.fieldNames.length;
+  const out=new Float32Array(DENSE_W*DENSE_H*F);
 
-  const lmeta=await idbGet(this._db, STORE_LMETA, key);
-  const buf=await idbGet(this._db, STORE_LAYER, key);
-
-  if (!buf){
-    const tmpl=await this._ensureZeroTemplate();
-    const arr=denseFromQuadrants(tmpl, targetSchema);
-    await this._applySparseIntoDense(z, arr);
-    await idbPut(this._db, STORE_LAYER, key, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-    this._layerCache.set(key,arr); return arr;
-  }
-
-  const curSid=lmeta?.sid|0;
-  const curList=lmeta?.fields || [];
-  if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(buf);
-    this._layerCache.set(key,arr); return arr;
-  }
-
-  const old=new Float32Array(buf);
-  const Fold=curList.length;
-  const Fnew=targetSchema.fieldNames.length;
-  const out=new Float32Array(DENSE_W*DENSE_H*Fnew);
-  const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-
-  for (let y=0;y<DENSE_H;y++){
-    const rowOld=y*DENSE_W*Fold;
-    const rowNew=y*DENSE_W*Fnew;
-    for (let x=0;x<DENSE_W;x++){
-      const baseOld=rowOld + x*Fold;
-      const baseNew=rowNew + x*Fnew;
-      for (const [name, fiNew] of targetSchema.index){
-        const fiOld=oldIdx.get(name);
-        if (fiOld!=null) out[baseNew+fiNew] = old[baseOld+fiOld];
-      }
+  for(let q=0;q<qCount;q++){
+    const bounds=quadrantBounds(layout,q);
+    const qa=await this._ensureQuadrantLayer(z,q);
+    const w=bounds.w,h=bounds.h;
+    for(let y=0;y<h;y++){
+      const rowOut=(bounds.yStart+y)*DENSE_W*F + bounds.xStart*F;
+      const rowQ=y*w*F;
+      out.set(qa.subarray(rowQ,rowQ+w*F), rowOut);
     }
   }
-  await idbPut(this._db, STORE_LAYER, key, out.buffer);
-  await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-  this._layerCache.set(key,out); return out;
+  this._layerCache.set(key,out);
+  return out;
 }
 
 export function _mapCellToDense(z, x, y){
@@ -117,75 +178,83 @@ export function _mapCellToDense(z, x, y){
   return { bx, by };
 }
 
-export async function _applySparseIntoDense(z, arr){
-  const F=this.schema.fieldNames.length;
-  const applyFields=this.schema.fieldNames;
-  for (const key in this.dataTable){
-    const parts=key.split(',');
-    const zi=Number(parts[2]||-1);
-    if (zi !== (z|0)) continue;
-    const x=Number(parts[0]), y=Number(parts[1]);
-    if (x<0||x>=this.state.cellsX||y<0||y>=this.state.cellsY) continue;
-    const { bx, by } = this._mapCellToDense(z, x, y);
-    const base=this._denseIdx(F, bx, by, 0);
-    const src=this.dataTable[key];
-    for (let fi=0; fi<F; fi++){
-      const name=applyFields[fi];
-      const v=src[name] || 0;
-      if (v!==0) arr[base+fi]=v;
-    }
-  }
-}
-
 export async function setDenseFromCell(z, xCell, yCell, values){
-  const arr=await this._ensureDenseLayer(z);
-  const F=this.schema.fieldNames.length;
   const { bx, by } = this._mapCellToDense(z, xCell, yCell);
-  const base=this._denseIdx(F, bx, by, 0);
+  const layout=quadrantLayout(this.quadrantCount || DEFAULT_QUADRANT_COUNT);
+  const qx=Math.floor(bx/layout.qW);
+  const qy=Math.floor(by/layout.qH);
+  const qIdx=qy*layout.cols+qx;
+  const bounds=quadrantBounds(layout,qIdx);
+  const lx=bx-bounds.xStart, ly=by-bounds.yStart;
+  const key=`${z}:${qIdx}`;
+  const qArr=await this._ensureQuadrantLayer(z,qIdx);
+  const F=this.schema.fieldNames.length;
+  const base=(ly*bounds.w + lx)*F;
   for (const [name,v] of Object.entries(values)){
     const fi=this.schema.index.get(name); if (fi==null) continue;
-    arr[base+fi] = v;
+    qArr[base+fi]=v;
+    if (this._layerCache.has(z|0)){
+      const arr=this._layerCache.get(z|0); arr[this._denseIdx(F,bx,by,fi)]=v;
+    }
     this._maxField[name] = Math.max(this._maxField[name]||0, v||0);
     if (name==='O2') this._maxO2=Math.max(this._maxO2, v||0);
   }
-  this._dirtyLayers.add(z|0);
-  if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
+  this._dirtyQuadrants.add(key);
+  if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(),200);
 }
 
 export async function addDenseFromCell(z, xCell, yCell, values){
-  const arr=await this._ensureDenseLayer(z);
-  const F=this.schema.fieldNames.length;
   const { bx, by } = this._mapCellToDense(z, xCell, yCell);
-  const base=this._denseIdx(F, bx, by, 0);
+  const layout=quadrantLayout(this.quadrantCount || DEFAULT_QUADRANT_COUNT);
+  const qx=Math.floor(bx/layout.qW);
+  const qy=Math.floor(by/layout.qH);
+  const qIdx=qy*layout.cols+qx;
+  const bounds=quadrantBounds(layout,qIdx);
+  const lx=bx-bounds.xStart, ly=by-bounds.yStart;
+  const key=`${z}:${qIdx}`;
+  const qArr=await this._ensureQuadrantLayer(z,qIdx);
+  const F=this.schema.fieldNames.length;
+  const base=(ly*bounds.w + lx)*F;
   for (const [name,inc] of Object.entries(values)){
     const fi=this.schema.index.get(name); if (fi==null) continue;
-    const nxt=(arr[base+fi]||0) + inc;
-    arr[base+fi] = nxt;
-    this._maxField[name] = Math.max(this._maxField[name]||0, nxt);
-    if (name==='O2') this._maxO2=Math.max(this._maxO2, nxt);
+    const nxt=(qArr[base+fi]||0)+inc;
+    qArr[base+fi]=nxt;
+    if (this._layerCache.has(z|0)){
+      const arr=this._layerCache.get(z|0); arr[this._denseIdx(F,bx,by,fi)]=nxt;
+    }
+    this._maxField[name]=Math.max(this._maxField[name]||0,nxt);
+    if (name==='O2') this._maxO2=Math.max(this._maxO2,nxt);
   }
-  this._dirtyLayers.add(z|0);
-  if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
+  this._dirtyQuadrants.add(key);
+  if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(),200);
 }
 
 export async function sampleDenseForCell(z, xCell, yCell, field){
   const fi=this.schema.index.get(field); if (fi==null) return 0;
-  const arr=await this._ensureDenseLayer(z);
-  const F=this.schema.fieldNames.length;
   const { bx, by } = this._mapCellToDense(z, xCell, yCell);
-  return arr[this._denseIdx(F, bx, by, fi)] || 0;
+  const layout=quadrantLayout(this.quadrantCount || DEFAULT_QUADRANT_COUNT);
+  const qx=Math.floor(bx/layout.qW);
+  const qy=Math.floor(by/layout.qH);
+  const qIdx=qy*layout.cols+qx;
+  const bounds=quadrantBounds(layout,qIdx);
+  const lx=bx-bounds.xStart, ly=by-bounds.yStart;
+  const qArr=await this._ensureQuadrantLayer(z,qIdx);
+  const F=this.schema.fieldNames.length;
+  return qArr[(ly*bounds.w + lx)*F + fi] || 0;
 }
 
 export async function _flushDirtyLayers(){
   if (this._disposed){ this._flushHandle=null; return; }
-  if (!this._db || !this._dirtyLayers.size){ this._flushHandle=null; return; }
-  const zs=Array.from(this._dirtyLayers);
-  this._dirtyLayers.clear();
-  await Promise.all(zs.map(async z=>{
-    const arr=this._layerCache.get(z|0);
-    if (arr) await idbPut(this._db, STORE_LAYER, z|0, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
+  if (!this._db || !this._dirtyQuadrants.size){ this._flushHandle=null; return; }
+  const keys=Array.from(this._dirtyQuadrants);
+  this._dirtyQuadrants.clear();
+  const zSet=new Set();
+  await Promise.all(keys.map(async k=>{
+    const arr=this._quadrantCache.get(k);
+    if (arr) await idbPut(this._db, STORE_LAYER, k, arr.buffer);
+    const z=Number(k.split(':')[0]); zSet.add(z);
   }));
+  await Promise.all(Array.from(zSet, z=>idbPut(this._db, STORE_LMETA, z, { sid:this.schema.id, fields:this.schema.fieldNames })));
   this._flushHandle=null;
 }
 

--- a/SDFGridParticles.js
+++ b/SDFGridParticles.js
@@ -46,7 +46,7 @@ export async function updateParticles(particles, dt){
     const vals=Object.fromEntries(this.schema.fieldNames.map(n=>[n,inc]));
     await this.addDenseFromCell(c.z, c.x, c.y, vals);
   }
-  if (!this._flushHandle && this._dirtyLayers.size) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
+  if (!this._flushHandle && this._dirtyQuadrants.size) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 
   this.updateDispersion(dt);
   if (this._disposed || this._rev!==rev) return;

--- a/SDFGridQuadrants.js
+++ b/SDFGridQuadrants.js
@@ -1,4 +1,5 @@
 import { DENSE_W, DENSE_H, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
+import { parseEnvExpression } from './SDFGridEnvExpressions.js';
 
 // Quantize environment variables using the Pareto principle (top 20% retained)
 export function quantizePareto(env){
@@ -14,11 +15,17 @@ export function quantizePareto(env){
   return out;
 }
 
-// Create a sparse quadrant template, quantizing each quadrant's environment variables
-export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envTemplate = {}){
+// Create sparse quadrants from serialized environment expressions
+// Each expression resolves to an object whose keys become the quadrant variables
+// with zero as the default value. Expressions can differ per quadrant.
+export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envExprs = []){
   const quads = [];
   for (let i=0; i<count; i++){
-    quads.push(quantizePareto(envTemplate));
+    const expr = envExprs[i] ?? envExprs[0] ?? {};
+    const tmpl = parseEnvExpression(expr);
+    const q = {};
+    for (const k of Object.keys(tmpl)) q[k] = 0;
+    quads.push(q);
   }
   return { quadrants: quads };
 }
@@ -27,19 +34,34 @@ export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envTemplat
 export function denseFromQuadrants(template, schema){
   const F = schema.fieldNames.length;
   const arr = new Float32Array(DENSE_W * DENSE_H * F);
-  if (!template?.quadrants || !template.quadrants.length) return arr;
-  const totalPixels = DENSE_W * DENSE_H;
-  const qCount = template.quadrants.length;
-  const areaPerQ = Math.ceil(totalPixels / qCount);
-  let pix = 0;
-  for (const quad of template.quadrants){
+  const quads = template?.quadrants || [];
+  const qCount = quads.length;
+  if (!qCount) return arr;
+
+  // Lay out quadrants across the 1024×1024 layer in a near-square grid
+  const cols = Math.ceil(Math.sqrt(qCount));
+  const rows = Math.ceil(qCount / cols);
+  const qW = Math.ceil(DENSE_W / cols);
+  const qH = Math.ceil(DENSE_H / rows);
+
+  for (let i=0; i<qCount; i++){
+    const quad = quads[i];
     const entries = Object.entries(quad);
-    const end = Math.min(pix + areaPerQ, totalPixels);
-    for (; pix < end; pix++){
-      const base = pix * F;
-      for (const [name, val] of entries){
-        const fi = schema.index.get(name);
-        if (fi != null) arr[base + fi] = val;
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const xStart = col * qW;
+    const yStart = row * qH;
+    const xEnd = Math.min(xStart + qW, DENSE_W);
+    const yEnd = Math.min(yStart + qH, DENSE_H);
+
+    for (let y=yStart; y<yEnd; y++){
+      const rowBase = y * DENSE_W * F;
+      for (let x=xStart; x<xEnd; x++){
+        const base = rowBase + x * F;
+        for (const [name, val] of entries){
+          const fi = schema.index.get(name);
+          if (fi != null) arr[base + fi] = val;
+        }
       }
     }
   }

--- a/SDFGridState.js
+++ b/SDFGridState.js
@@ -84,7 +84,8 @@ export async function updateGrid(params){
   { const w=this.state.cellsX,h=this.state.cellsY,dir=params?.propagationDir||{x:1,y:0}; const pick=()=>pickNucleusByDirection(w,h,dir); for(let z=0; z<this.effectiveCellsZ; z++) this._nuclei[z]=pick(); }
 
   this._layerCache.clear();
-  this._dirtyLayers.clear();
+  this._quadrantCache.clear();
+  this._dirtyQuadrants.clear();
   if (this._flushHandle){ clearTimeout(this._flushHandle); this._flushHandle=null; }
 
   this.initializeGrid();
@@ -199,6 +200,6 @@ export function dispose(){
     this.gridGroup=null; this.instancedMesh=null;
   }
   this._layerCache.clear();
-  this._dirtyLayers.clear();
+  this._dirtyQuadrants.clear();
   this.constructor._instances?.delete(this.uid);
 }


### PR DESCRIPTION
## Summary
- Introduce `_ensureQuadrantLayer` and quadrant cache so overlay data persists per quadrant instead of whole layers
- Route cell updates to their quadrant buffers and mark only those segments dirty
- Flush routine writes back just changed quadrants and maintains per-layer schema metadata

## Testing
- `node --check SDFGridLayers.js`
- `node --check SDFGridCore.js`
- `node --check SDFGridParticles.js`
- `node --check SDFGridState.js`


------
https://chatgpt.com/codex/tasks/task_e_68c776a34bf4832db29489bf2ce8602e