### PR TITLE
Persist overlays per quadrant for granular updates

### DIFF
--- a/SDFGridConstants.js
+++ b/SDFGridConstants.js
@@ -3,13 +3,14 @@ export const DENSE_W = 1024;
 export const DENSE_H = 1024;
 
 export const IDB_NAME    = 'SDFFieldDB';
-export const IDB_VERSION = 7;
+export const IDB_VERSION = 8;
 
 export const STORE_META  = 'meta';
 export const STORE_BASE  = 'base';        // Int16 SDF per-layer (kept)
 // Sparse quadrant template per schemaId
 export const STORE_BASEZ = 'base_zero';
-export const STORE_LAYER = 'overlay_layers';
+// Per-layer quadrants for dense overlays
+export const STORE_LAYER_Q = 'overlay_quadrants';
 export const STORE_LMETA = 'overlay_layers_meta';
 
 // Default number of quadrants for environment quantization

--- a/SDFGridCore.js
+++ b/SDFGridCore.js
@@ -6,7 +6,7 @@
 // and applies any existing sparse cell data center-aligned; zeros remain as padding.
 //
 // IDB inside a Storage Bucket named after UID (lowercased, sanitized):
-//   DB: 'SDFFieldDB'  (version 7)
+//   DB: 'SDFFieldDB'  (version 8)
 //   Stores:
 //     'meta'                : layout, global schema, per-layer nuclei
 //       - 'layout'          : { w,h,layers, denseW,denseH, shapeType, gw,gh,gd }
@@ -15,7 +15,7 @@
 //     'base'                : per-layer Int16 SDF (key = z)    [kept for SDF usage]
 //     'base_zero'           : sparse quadrant templates        [NEW]
 //         key = `sid:${schemaId}`  -> { quadrants: Array }
-//     'overlay_layers'      : per-layer Float32 dense, key = z
+//     'overlay_quadrants'   : per-layer Float32 dense pieces, key = `${z},${qi}`
 //     'overlay_layers_meta' : per-layer schema version { sid, fields }, key = z
 //
 // Console helpers exposed: SDF_layerInfo(uid,z), SDF_readCell(uid,z,x,y), SDF_centerCell(uid,z)
@@ -103,7 +103,7 @@ export class SDFGrid{
 
     // caches and batching
     this._layerCache = new Map(); // z -> Float32Array (dense)
-    this._dirtyLayers = new Set();
+    this._dirtyQuadrants = new Map(); // z -> Set of dirty quadrant indices
     this._flushHandle = null;
 
     // stats

--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -1,7 +1,67 @@
-import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
+import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER_Q, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import { arraysEqual } from './SDFGridUtil.js';
 import { idbGet, idbPut } from './SDFGridStorage.js';
 import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js';
+
+function quadrantSpec(self){
+  const count=self.quadrantCount || DEFAULT_QUADRANT_COUNT;
+  const cols=Math.ceil(Math.sqrt(count));
+  const rows=Math.ceil(count/cols);
+  const qW=Math.ceil(DENSE_W/cols);
+  const qH=Math.ceil(DENSE_H/rows);
+  return { count, cols, rows, qW, qH };
+}
+
+function quadrantRange(self, qi){
+  const {cols,qW,qH}=quadrantSpec(self);
+  const col=qi%cols;
+  const row=Math.floor(qi/cols);
+  const xStart=col*qW;
+  const yStart=row*qH;
+  const xEnd=Math.min(xStart+qW, DENSE_W);
+  const yEnd=Math.min(yStart+qH, DENSE_H);
+  return { xStart,xEnd,yStart,yEnd };
+}
+
+function quadrantIndexFromDense(self,bx,by){
+  const spec=quadrantSpec(self);
+  const col=Math.min(spec.cols-1, Math.floor(bx/spec.qW));
+  const row=Math.min(spec.rows-1, Math.floor(by/spec.qH));
+  return row*spec.cols+col;
+}
+
+function blitQuadrantIntoDense(self,dest,src,qi,F){
+  const {xStart,xEnd,yStart,yEnd}=quadrantRange(self,qi);
+  let p=0;
+  for(let y=yStart;y<yEnd;y++){
+    const rowBase=y*DENSE_W*F;
+    for(let x=xStart;x<xEnd;x++){
+      const base=rowBase+x*F;
+      for(let fi=0;fi<F;fi++) dest[base+fi]=src[p++];
+    }
+  }
+}
+
+function extractQuadrantBuffer(self,src,qi,F){
+  const {xStart,xEnd,yStart,yEnd}=quadrantRange(self,qi);
+  const out=new Float32Array((xEnd-xStart)*(yEnd-yStart)*F);
+  let p=0;
+  for(let y=yStart;y<yEnd;y++){
+    const rowBase=y*DENSE_W*F;
+    for(let x=xStart;x<xEnd;x++){
+      const base=rowBase+x*F;
+      for(let fi=0;fi<F;fi++) out[p++]=src[base+fi];
+    }
+  }
+  return out;
+}
+
+function markDirty(self,z,bx,by){
+  const qi=quadrantIndexFromDense(self,bx,by);
+  let set=self._dirtyQuadrants.get(z|0);
+  if(!set){ set=new Set(); self._dirtyQuadrants.set(z|0,set); }
+  set.add(qi);
+}
 
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
@@ -63,45 +123,65 @@ export async function _ensureDenseLayer(z){
   }
 
   const lmeta=await idbGet(this._db, STORE_LMETA, key);
-  const buf=await idbGet(this._db, STORE_LAYER, key);
-
-  if (!buf){
-    const tmpl=await this._ensureZeroTemplate();
-    const arr=denseFromQuadrants(tmpl, targetSchema);
-    await this._applySparseIntoDense(z, arr);
-    await idbPut(this._db, STORE_LAYER, key, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-    this._layerCache.set(key,arr); return arr;
-  }
-
   const curSid=lmeta?.sid|0;
   const curList=lmeta?.fields || [];
+  const tmpl=await this._ensureZeroTemplate();
+  const Fnew=targetSchema.fieldNames.length;
+  const { count:qCount } = quadrantSpec(this);
+
   if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(buf);
+    let arr=denseFromQuadrants(tmpl, targetSchema);
+    const buffers=await Promise.all(Array.from({length:qCount}, (_,qi)=>idbGet(this._db, STORE_LAYER_Q, `${key},${qi}`)));
+    let allPresent=true;
+    for(let qi=0; qi<qCount; qi++){
+      const buf=buffers[qi];
+      if (buf){
+        blitQuadrantIntoDense(this, arr, new Float32Array(buf), qi, Fnew);
+      } else {
+        allPresent=false;
+      }
+    }
+    if (!allPresent){
+      await this._applySparseIntoDense(z, arr);
+      await Promise.all(Array.from({length:qCount}, (_,qi)=>{
+        const qb=extractQuadrantBuffer(this, arr, qi, Fnew);
+        return idbPut(this._db, STORE_LAYER_Q, `${key},${qi}`, qb.buffer);
+      }));
+      await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+    }
     this._layerCache.set(key,arr); return arr;
   }
 
-  const old=new Float32Array(buf);
-  const Fold=curList.length;
-  const Fnew=targetSchema.fieldNames.length;
-  const out=new Float32Array(DENSE_W*DENSE_H*Fnew);
+  const oldF=curList.length;
+  let arrOld=null;
+  if (oldF){
+    arrOld=new Float32Array(DENSE_W*DENSE_H*oldF);
+    const buffers=await Promise.all(Array.from({length:qCount}, (_,qi)=>idbGet(this._db, STORE_LAYER_Q, `${key},${qi}`)));
+    for(let qi=0; qi<qCount; qi++){
+      const buf=buffers[qi];
+      if (buf) blitQuadrantIntoDense(this, arrOld, new Float32Array(buf), qi, oldF);
+    }
+  }
+  let arr=denseFromQuadrants(tmpl, targetSchema);
   const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-
   for (let y=0;y<DENSE_H;y++){
-    const rowOld=y*DENSE_W*Fold;
+    const rowOld=y*DENSE_W*oldF;
     const rowNew=y*DENSE_W*Fnew;
     for (let x=0;x<DENSE_W;x++){
-      const baseOld=rowOld + x*Fold;
+      const baseOld=rowOld + x*oldF;
       const baseNew=rowNew + x*Fnew;
       for (const [name, fiNew] of targetSchema.index){
         const fiOld=oldIdx.get(name);
-        if (fiOld!=null) out[baseNew+fiNew] = old[baseOld+fiOld];
+        if (fiOld!=null && arrOld) arr[baseNew+fiNew]=arrOld[baseOld+fiOld];
       }
     }
   }
-  await idbPut(this._db, STORE_LAYER, key, out.buffer);
+  await Promise.all(Array.from({length:qCount}, (_,qi)=>{
+    const qb=extractQuadrantBuffer(this, arr, qi, Fnew);
+    return idbPut(this._db, STORE_LAYER_Q, `${key},${qi}`, qb.buffer);
+  }));
   await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-  this._layerCache.set(key,out); return out;
+  this._layerCache.set(key,arr); return arr;
 }
 
 export function _mapCellToDense(z, x, y){
@@ -148,7 +228,7 @@ export async function setDenseFromCell(z, xCell, yCell, values){
     this._maxField[name] = Math.max(this._maxField[name]||0, v||0);
     if (name==='O2') this._maxO2=Math.max(this._maxO2, v||0);
   }
-  this._dirtyLayers.add(z|0);
+  markDirty(this, z, bx, by);
   if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 }
 
@@ -164,7 +244,7 @@ export async function addDenseFromCell(z, xCell, yCell, values){
     this._maxField[name] = Math.max(this._maxField[name]||0, nxt);
     if (name==='O2') this._maxO2=Math.max(this._maxO2, nxt);
   }
-  this._dirtyLayers.add(z|0);
+  markDirty(this, z, bx, by);
   if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 }
 
@@ -178,13 +258,19 @@ export async function sampleDenseForCell(z, xCell, yCell, field){
 
 export async function _flushDirtyLayers(){
   if (this._disposed){ this._flushHandle=null; return; }
-  if (!this._db || !this._dirtyLayers.size){ this._flushHandle=null; return; }
-  const zs=Array.from(this._dirtyLayers);
-  this._dirtyLayers.clear();
-  await Promise.all(zs.map(async z=>{
+  if (!this._db || !this._dirtyQuadrants.size){ this._flushHandle=null; return; }
+  const entries=Array.from(this._dirtyQuadrants.entries());
+  this._dirtyQuadrants.clear();
+  const F=this.schema.fieldNames.length;
+  await Promise.all(entries.map(async ([z,set])=>{
     const arr=this._layerCache.get(z|0);
-    if (arr) await idbPut(this._db, STORE_LAYER, z|0, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
+    if (arr){
+      await Promise.all(Array.from(set).map(async qi=>{
+        const qb=extractQuadrantBuffer(this, arr, qi, F);
+        await idbPut(this._db, STORE_LAYER_Q, `${z|0},${qi}`, qb.buffer);
+      }));
+      await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
+    }
   }));
   this._flushHandle=null;
 }

--- a/SDFGridParticles.js
+++ b/SDFGridParticles.js
@@ -46,7 +46,7 @@ export async function updateParticles(particles, dt){
     const vals=Object.fromEntries(this.schema.fieldNames.map(n=>[n,inc]));
     await this.addDenseFromCell(c.z, c.x, c.y, vals);
   }
-  if (!this._flushHandle && this._dirtyLayers.size) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
+  if (!this._flushHandle && this._dirtyQuadrants.size) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 
   this.updateDispersion(dt);
   if (this._disposed || this._rev!==rev) return;

--- a/SDFGridState.js
+++ b/SDFGridState.js
@@ -84,7 +84,7 @@ export async function updateGrid(params){
   { const w=this.state.cellsX,h=this.state.cellsY,dir=params?.propagationDir||{x:1,y:0}; const pick=()=>pickNucleusByDirection(w,h,dir); for(let z=0; z<this.effectiveCellsZ; z++) this._nuclei[z]=pick(); }
 
   this._layerCache.clear();
-  this._dirtyLayers.clear();
+  this._dirtyQuadrants.clear();
   if (this._flushHandle){ clearTimeout(this._flushHandle); this._flushHandle=null; }
 
   this.initializeGrid();
@@ -199,6 +199,6 @@ export function dispose(){
     this.gridGroup=null; this.instancedMesh=null;
   }
   this._layerCache.clear();
-  this._dirtyLayers.clear();
+  this._dirtyQuadrants.clear();
   this.constructor._instances?.delete(this.uid);
 }

--- a/SDFGridStorage.js
+++ b/SDFGridStorage.js
@@ -1,5 +1,5 @@
 // IndexedDB and Storage Bucket helpers for SDFGrid
-import { IDB_NAME, IDB_VERSION, STORE_META, STORE_BASE, STORE_LAYER, STORE_LMETA, STORE_BASEZ } from './SDFGridConstants.js';
+import { IDB_NAME, IDB_VERSION, STORE_META, STORE_BASE, STORE_LAYER_Q, STORE_LMETA, STORE_BASEZ } from './SDFGridConstants.js';
 
 export async function openBucketLC(nameLC){
   if (!nameLC || !navigator.storageBuckets) return null;
@@ -13,7 +13,7 @@ export function openFieldDB(bucket){
       const db=e.target.result;
       if (!db.objectStoreNames.contains(STORE_META))  db.createObjectStore(STORE_META);
       if (!db.objectStoreNames.contains(STORE_BASE))  db.createObjectStore(STORE_BASE);
-      if (!db.objectStoreNames.contains(STORE_LAYER)) db.createObjectStore(STORE_LAYER);
+      if (!db.objectStoreNames.contains(STORE_LAYER_Q)) db.createObjectStore(STORE_LAYER_Q);
       if (!db.objectStoreNames.contains(STORE_LMETA)) db.createObjectStore(STORE_LMETA);
       if (!db.objectStoreNames.contains(STORE_BASEZ)) db.createObjectStore(STORE_BASEZ);
     };


### PR DESCRIPTION
## Summary
- Break overlay storage into per-quadrant chunks for finer updates.
- Track dirty quadrants and flush only modified regions.
- Add new IndexedDB store and bump DB version.

## Testing
- `node --input-type=module -e "import('./SDFGrid.js').then(()=>console.log('loaded')).catch(e=>console.error(e.message))"` *(fails: Cannot find module '/workspace/Modularization/utils.js' imported from /workspace/Modularization/SDFGridCore.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c7971a9a98832db640860faa70d92a