### PR TITLE
Store dense layers per quadrant for granular updates

### DIFF
--- a/SDFGridCore.js
+++ b/SDFGridCore.js
@@ -1,9 +1,10 @@
-// SDFGrid.js — dense 1024×1024 per-layer Float32 overlay with sparse quadrant base,
-// nucleus-centered alignment, SVG SDF, and Storage Buckets persistence.
+// SDFGrid.js — dense 1024×1024 Float32 overlay subdivided into quadrants with a sparse
+// quadrant base, nucleus-centered alignment, SVG SDF, and Storage Buckets persistence.
 //
-// Dense overlay: one Float32Array per layer, length = 1024 * 1024 * F (F = #fields).
-// First creation of a layer clones a quantized quadrant template from the base store (base_zero)
-// and applies any existing sparse cell data center-aligned; zeros remain as padding.
+// Dense overlay: each layer is broken into near-square quadrants stored independently.
+// First creation of a layer clones a quantized quadrant template from the base store
+// (base_zero) and applies any existing sparse cell data center-aligned; zeros remain as
+// padding.
 //
 // IDB inside a Storage Bucket named after UID (lowercased, sanitized):
 //   DB: 'SDFFieldDB'  (version 7)
@@ -15,8 +16,8 @@
 //     'base'                : per-layer Int16 SDF (key = z)    [kept for SDF usage]
 //     'base_zero'           : sparse quadrant templates        [NEW]
 //         key = `sid:${schemaId}`  -> { quadrants: Array }
-//     'overlay_layers'      : per-layer Float32 dense, key = z
-//     'overlay_layers_meta' : per-layer schema version { sid, fields }, key = z
+//     'overlay_layers'      : per-quadrant Float32 dense, key = `${z},${q}`
+//     'overlay_layers_meta' : per-layer schema { sid, fields, qCount }, key = z
 //
 // Console helpers exposed: SDF_layerInfo(uid,z), SDF_readCell(uid,z,x,y), SDF_centerCell(uid,z)
 //
@@ -32,8 +33,8 @@ import { compileLogic } from './SDFGridLogic.js';
 import { createInterpolatedShapes, sdf, sdfGrad } from './SDFGridShape.js';
 import { DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import {
-  _ensureZeroTemplate, _ensureBaseSDF, getBaseDistance, _denseIdx, _ensureDenseLayer,
-  _mapCellToDense, _applySparseIntoDense, setDenseFromCell, addDenseFromCell,
+  _ensureZeroTemplate, _ensureBaseSDF, getBaseDistance, _ensureDenseLayer,
+  _mapCellToDense, _mapDenseToQuadrant, _applySparseIntoDense, setDenseFromCell, addDenseFromCell,
   sampleDenseForCell, _flushDirtyLayers
 } from './SDFGridLayers.js';
 import { updateParticles } from './SDFGridParticles.js';
@@ -102,8 +103,8 @@ export class SDFGrid{
     this.fieldForViz = params.fieldForViz || (initialFields.includes('O2') ? 'O2' : initialFields[0]);
 
     // caches and batching
-    this._layerCache = new Map(); // z -> Float32Array (dense)
-    this._dirtyLayers = new Set();
+    this._layerCache = new Map(); // z -> { quads:Float32Array[], cols, rows, qW, qH }
+    this._dirtyLayers = new Map(); // z -> Set(quadrant indices)
     this._flushHandle = null;
 
     // stats
@@ -163,9 +164,9 @@ Object.assign(SDFGrid.prototype, {
   _ensureZeroTemplate,
   _ensureBaseSDF,
   getBaseDistance,
-  _denseIdx,
   _ensureDenseLayer,
   _mapCellToDense,
+  _mapDenseToQuadrant,
   _applySparseIntoDense,
   setDenseFromCell,
   addDenseFromCell,

--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -1,7 +1,7 @@
 import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import { arraysEqual } from './SDFGridUtil.js';
 import { idbGet, idbPut } from './SDFGridStorage.js';
-import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js';
+import { createSparseQuadrants } from './SDFGridQuadrants.js';
 
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
@@ -52,56 +52,92 @@ export function _denseIdx(F,xPix,yPix,fi){
   return ((yPix*DENSE_W)+xPix)*F + fi;
 }
 
+function _quadrantLayout(count){
+  const cols=Math.ceil(Math.sqrt(count));
+  const rows=Math.ceil(count/cols);
+  const qW=Math.ceil(DENSE_W/cols);
+  const qH=Math.ceil(DENSE_H/rows);
+  return { cols, rows, qW, qH, total:cols*rows };
+}
+
+export function _mapDenseToQuadrant(layer, bx, by){
+  const qcol=Math.min(layer.cols-1, Math.floor(bx/layer.qW));
+  const qrow=Math.min(layer.rows-1, Math.floor(by/layer.qH));
+  const qi=qrow*layer.cols+qcol;
+  const qx=bx - qcol*layer.qW;
+  const qy=by - qrow*layer.qH;
+  return { qi, qx, qy };
+}
+
 export async function _ensureDenseLayer(z){
   const key=z|0;
   if (this._layerCache.has(key)) return this._layerCache.get(key);
 
   const targetSchema=this.schema;
+  const tmpl=await this._ensureZeroTemplate();
+  const qCount=this.quadrantCount || DEFAULT_QUADRANT_COUNT;
+  const { cols, rows, qW, qH, total }=_quadrantLayout(qCount);
+  const Fnew=targetSchema.fieldNames.length;
+  const layer={ quads:new Array(total), cols, rows, qW, qH };
+
   if (!this._db){
-    const arr=new Float32Array(DENSE_W*DENSE_H*targetSchema.fieldNames.length);
-    this._layerCache.set(key,arr); return arr;
+    for(let i=0;i<total;i++) layer.quads[i]=new Float32Array(qW*qH*Fnew);
+    this._layerCache.set(key,layer);
+    return layer;
   }
 
   const lmeta=await idbGet(this._db, STORE_LMETA, key);
-  const buf=await idbGet(this._db, STORE_LAYER, key);
-
-  if (!buf){
-    const tmpl=await this._ensureZeroTemplate();
-    const arr=denseFromQuadrants(tmpl, targetSchema);
-    await this._applySparseIntoDense(z, arr);
-    await idbPut(this._db, STORE_LAYER, key, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-    this._layerCache.set(key,arr); return arr;
-  }
-
   const curSid=lmeta?.sid|0;
   const curList=lmeta?.fields || [];
-  if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(buf);
-    this._layerCache.set(key,arr); return arr;
-  }
+  const curQ=lmeta?.qCount || qCount;
+  const { qW:qW0, qH:qH0, total:tot0 }=_quadrantLayout(curQ);
 
-  const old=new Float32Array(buf);
-  const Fold=curList.length;
-  const Fnew=targetSchema.fieldNames.length;
-  const out=new Float32Array(DENSE_W*DENSE_H*Fnew);
-  const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-
-  for (let y=0;y<DENSE_H;y++){
-    const rowOld=y*DENSE_W*Fold;
-    const rowNew=y*DENSE_W*Fnew;
-    for (let x=0;x<DENSE_W;x++){
-      const baseOld=rowOld + x*Fold;
-      const baseNew=rowNew + x*Fnew;
-      for (const [name, fiNew] of targetSchema.index){
-        const fiOld=oldIdx.get(name);
-        if (fiOld!=null) out[baseNew+fiNew] = old[baseOld+fiOld];
+  for(let qi=0; qi<total; qi++){
+    const buf=await idbGet(this._db, STORE_LAYER, `${key},${qi}`);
+    let arr;
+    if (buf && curSid===targetSchema.id && arraysEqual(curList, targetSchema.fieldNames) && tot0===total && qW0===qW && qH0===qH){
+      arr=new Float32Array(buf);
+    } else if (buf){
+      const old=new Float32Array(buf);
+      const Fold=curList.length;
+      arr=new Float32Array(qW*qH*Fnew);
+      const oldIdx=new Map(curList.map((n,i)=>[n,i]));
+      const cellCount=Math.min(old.length/Fold, qW*qH);
+      for(let i=0;i<cellCount;i++){
+        const baseOld=i*Fold;
+        const baseNew=i*Fnew;
+        for (const [name, fiNew] of targetSchema.index){
+          const fiOld=oldIdx.get(name);
+          if (fiOld!=null) arr[baseNew+fiNew]=old[baseOld+fiOld];
+        }
+      }
+    } else {
+      const quad=tmpl.quadrants[qi] || {};
+      arr=new Float32Array(qW*qH*Fnew);
+      const entries=Object.entries(quad);
+      if (entries.length){
+        for(let y=0;y<qH;y++){
+          const row=y*qW*Fnew;
+          for(let x=0;x<qW;x++){
+            const base=row+x*Fnew;
+            for(const [name,val] of entries){
+              const fi=targetSchema.index.get(name);
+              if (fi!=null) arr[base+fi]=val;
+            }
+          }
+        }
       }
     }
+    layer.quads[qi]=arr;
   }
-  await idbPut(this._db, STORE_LAYER, key, out.buffer);
-  await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-  this._layerCache.set(key,out); return out;
+
+  await this._applySparseIntoDense(z, layer);
+  if (this._db){
+    await Promise.all(layer.quads.map((arr,qi)=>idbPut(this._db, STORE_LAYER, `${key},${qi}`, arr.buffer)));
+    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames, qCount:layer.quads.length });
+  }
+  this._layerCache.set(key,layer);
+  return layer;
 }
 
 export function _mapCellToDense(z, x, y){
@@ -117,7 +153,7 @@ export function _mapCellToDense(z, x, y){
   return { bx, by };
 }
 
-export async function _applySparseIntoDense(z, arr){
+export async function _applySparseIntoDense(z, layer){
   const F=this.schema.fieldNames.length;
   const applyFields=this.schema.fieldNames;
   for (const key in this.dataTable){
@@ -127,7 +163,9 @@ export async function _applySparseIntoDense(z, arr){
     const x=Number(parts[0]), y=Number(parts[1]);
     if (x<0||x>=this.state.cellsX||y<0||y>=this.state.cellsY) continue;
     const { bx, by } = this._mapCellToDense(z, x, y);
-    const base=this._denseIdx(F, bx, by, 0);
+    const { qi, qx, qy } = _mapDenseToQuadrant(layer, bx, by);
+    const arr=layer.quads[qi];
+    const base=((qy*layer.qW)+qx)*F;
     const src=this.dataTable[key];
     for (let fi=0; fi<F; fi++){
       const name=applyFields[fi];
@@ -138,25 +176,30 @@ export async function _applySparseIntoDense(z, arr){
 }
 
 export async function setDenseFromCell(z, xCell, yCell, values){
-  const arr=await this._ensureDenseLayer(z);
+  const layer=await this._ensureDenseLayer(z);
   const F=this.schema.fieldNames.length;
   const { bx, by } = this._mapCellToDense(z, xCell, yCell);
-  const base=this._denseIdx(F, bx, by, 0);
+  const { qi, qx, qy } = _mapDenseToQuadrant(layer, bx, by);
+  const arr=layer.quads[qi];
+  const base=((qy*layer.qW)+qx)*F;
   for (const [name,v] of Object.entries(values)){
     const fi=this.schema.index.get(name); if (fi==null) continue;
     arr[base+fi] = v;
     this._maxField[name] = Math.max(this._maxField[name]||0, v||0);
     if (name==='O2') this._maxO2=Math.max(this._maxO2, v||0);
   }
-  this._dirtyLayers.add(z|0);
+  if (!this._dirtyLayers.has(z|0)) this._dirtyLayers.set(z|0,new Set());
+  this._dirtyLayers.get(z|0).add(qi);
   if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 }
 
 export async function addDenseFromCell(z, xCell, yCell, values){
-  const arr=await this._ensureDenseLayer(z);
+  const layer=await this._ensureDenseLayer(z);
   const F=this.schema.fieldNames.length;
   const { bx, by } = this._mapCellToDense(z, xCell, yCell);
-  const base=this._denseIdx(F, bx, by, 0);
+  const { qi, qx, qy } = _mapDenseToQuadrant(layer, bx, by);
+  const arr=layer.quads[qi];
+  const base=((qy*layer.qW)+qx)*F;
   for (const [name,inc] of Object.entries(values)){
     const fi=this.schema.index.get(name); if (fi==null) continue;
     const nxt=(arr[base+fi]||0) + inc;
@@ -164,27 +207,34 @@ export async function addDenseFromCell(z, xCell, yCell, values){
     this._maxField[name] = Math.max(this._maxField[name]||0, nxt);
     if (name==='O2') this._maxO2=Math.max(this._maxO2, nxt);
   }
-  this._dirtyLayers.add(z|0);
+  if (!this._dirtyLayers.has(z|0)) this._dirtyLayers.set(z|0,new Set());
+  this._dirtyLayers.get(z|0).add(qi);
   if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 }
 
 export async function sampleDenseForCell(z, xCell, yCell, field){
   const fi=this.schema.index.get(field); if (fi==null) return 0;
-  const arr=await this._ensureDenseLayer(z);
+  const layer=await this._ensureDenseLayer(z);
   const F=this.schema.fieldNames.length;
   const { bx, by } = this._mapCellToDense(z, xCell, yCell);
-  return arr[this._denseIdx(F, bx, by, fi)] || 0;
+  const { qi, qx, qy } = _mapDenseToQuadrant(layer, bx, by);
+  const arr=layer.quads[qi];
+  return arr ? (arr[((qy*layer.qW)+qx)*F + fi] || 0) : 0;
 }
 
 export async function _flushDirtyLayers(){
   if (this._disposed){ this._flushHandle=null; return; }
   if (!this._db || !this._dirtyLayers.size){ this._flushHandle=null; return; }
-  const zs=Array.from(this._dirtyLayers);
+  const entries=Array.from(this._dirtyLayers.entries());
   this._dirtyLayers.clear();
-  await Promise.all(zs.map(async z=>{
-    const arr=this._layerCache.get(z|0);
-    if (arr) await idbPut(this._db, STORE_LAYER, z|0, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
+  await Promise.all(entries.map(async ([z,qset])=>{
+    const layer=this._layerCache.get(z|0);
+    if (!layer) return;
+    await Promise.all(Array.from(qset).map(async qi=>{
+      const arr=layer.quads[qi];
+      if (arr) await idbPut(this._db, STORE_LAYER, `${z|0},${qi}`, arr.buffer);
+    }));
+    await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames, qCount:layer.quads.length });
   }));
   this._flushHandle=null;
 }

--- a/SDFGridVisualization.js
+++ b/SDFGridVisualization.js
@@ -106,8 +106,13 @@ export async function updateVisualization(){
   for (const [key,id] of im.instanceMap){
     const [x,y,z]=key.split(',').map(Number);
     const { bx, by } = this._mapCellToDense(z, x, y);
-    const arr=this._layerCache.get(z|0);
-    const val = arr ? (arr[this._denseIdx(F,bx,by,fi)] || 0) : 0;
+    const layer=this._layerCache.get(z|0);
+    let val=0;
+    if (layer){
+      const { qi, qx, qy } = this._mapDenseToQuadrant(layer, bx, by);
+      const arr=layer.quads[qi];
+      if (arr) val = arr[((qy*layer.qW)+qx)*F + fi] || 0;
+    }
     const norm=Math.min(1,(val<=0?0:val)/max);
     im.setColorAt(id, this._valueToColor(norm));
   }


### PR DESCRIPTION
## Summary
- Break overlay layers into independently stored quadrants
- Track dirty quadrants and flush only modified regions
- Update visualization to sample quadrant arrays

## Testing
- `node --input-type=module -e "import('./SDFGridLayers.js').then(()=>console.log('loaded')).catch(e=>console.error(e))"`
- `node --input-type=module -e "import('./SDFGridCore.js').then(()=>console.log('core loaded')).catch(e=>console.error(e))"` (fails: Cannot find module './utils.js')
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68c7971a9a98832db640860faa70d92a