### PR TITLE
Store overlay layers by quadrants

### DIFF
--- a/SDFGridConstants.js
+++ b/SDFGridConstants.js
@@ -13,4 +13,4 @@ export const STORE_LAYER = 'overlay_layers';
 export const STORE_LMETA = 'overlay_layers_meta';
 
 // Default number of quadrants for environment quantization
-export const DEFAULT_QUADRANT_COUNT = 10;
+export const DEFAULT_QUADRANT_COUNT = 16;

--- a/SDFGridCore.js
+++ b/SDFGridCore.js
@@ -103,7 +103,7 @@ export class SDFGrid{
 
     // caches and batching
     this._layerCache = new Map(); // z -> Float32Array (dense)
-    this._dirtyLayers = new Set();
+    this._dirtyLayers = new Map(); // z -> Set of dirty quadrant indices
     this._flushHandle = null;
 
     // stats

--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -1,7 +1,13 @@
 import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import { arraysEqual } from './SDFGridUtil.js';
 import { idbGet, idbPut } from './SDFGridStorage.js';
-import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js';
+import {
+  createSparseQuadrants,
+  denseFromQuadrants,
+  buffersToDense,
+  extractQuadrantBuffer,
+  quadrantIndexForPixel
+} from './SDFGridQuadrants.js';
 
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
@@ -53,55 +59,74 @@ export function _denseIdx(F,xPix,yPix,fi){
 }
 
 export async function _ensureDenseLayer(z){
-  const key=z|0;
+  const key = z | 0;
   if (this._layerCache.has(key)) return this._layerCache.get(key);
 
-  const targetSchema=this.schema;
+  const targetSchema = this.schema;
+  const qCount = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
+  const Fnew = targetSchema.fieldNames.length;
+
   if (!this._db){
-    const arr=new Float32Array(DENSE_W*DENSE_H*targetSchema.fieldNames.length);
-    this._layerCache.set(key,arr); return arr;
+    const arr = new Float32Array(DENSE_W * DENSE_H * Fnew);
+    this._layerCache.set(key, arr); return arr;
   }
 
-  const lmeta=await idbGet(this._db, STORE_LMETA, key);
-  const buf=await idbGet(this._db, STORE_LAYER, key);
+  const lmeta = await idbGet(this._db, STORE_LMETA, key);
+  const storedCount = lmeta?.quadrantCount || qCount;
+  const curSid = lmeta?.sid | 0;
+  const curList = lmeta?.fields || [];
 
-  if (!buf){
-    const tmpl=await this._ensureZeroTemplate();
-    const arr=denseFromQuadrants(tmpl, targetSchema);
+  const buffers = await Promise.all(
+    Array.from({ length: storedCount }, (_, i) => idbGet(this._db, STORE_LAYER, `${key}:${i}`))
+  );
+  const hasAny = buffers.some(buf => buf);
+
+  if (!hasAny){
+    const tmpl = await this._ensureZeroTemplate();
+    const arr = denseFromQuadrants(tmpl, targetSchema);
     await this._applySparseIntoDense(z, arr);
-    await idbPut(this._db, STORE_LAYER, key, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-    this._layerCache.set(key,arr); return arr;
+    for (let q=0; q<qCount; q++){
+      const qb = extractQuadrantBuffer(arr, q, qCount, Fnew);
+      await idbPut(this._db, STORE_LAYER, `${key}:${q}`, qb);
+    }
+    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames, quadrantCount:qCount });
+    this._layerCache.set(key, arr); return arr;
   }
 
-  const curSid=lmeta?.sid|0;
-  const curList=lmeta?.fields || [];
-  if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(buf);
-    this._layerCache.set(key,arr); return arr;
-  }
+  const Fold = curList.length || Fnew;
+  let arr = buffersToDense(buffers, storedCount, Fold);
+  let needsSave = false;
 
-  const old=new Float32Array(buf);
-  const Fold=curList.length;
-  const Fnew=targetSchema.fieldNames.length;
-  const out=new Float32Array(DENSE_W*DENSE_H*Fnew);
-  const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-
-  for (let y=0;y<DENSE_H;y++){
-    const rowOld=y*DENSE_W*Fold;
-    const rowNew=y*DENSE_W*Fnew;
-    for (let x=0;x<DENSE_W;x++){
-      const baseOld=rowOld + x*Fold;
-      const baseNew=rowNew + x*Fnew;
-      for (const [name, fiNew] of targetSchema.index){
-        const fiOld=oldIdx.get(name);
-        if (fiOld!=null) out[baseNew+fiNew] = old[baseOld+fiOld];
+  if (curSid !== targetSchema.id || !arraysEqual(curList, targetSchema.fieldNames)){
+    const out = new Float32Array(DENSE_W * DENSE_H * Fnew);
+    const oldIdx = new Map(curList.map((n,i)=>[n,i]));
+    for (let y=0; y<DENSE_H; y++){
+      const rowOld = y * DENSE_W * Fold;
+      const rowNew = y * DENSE_W * Fnew;
+      for (let x=0; x<DENSE_W; x++){
+        const baseOld = rowOld + x * Fold;
+        const baseNew = rowNew + x * Fnew;
+        for (const [name, fiNew] of targetSchema.index){
+          const fiOld = oldIdx.get(name);
+          if (fiOld != null) out[baseNew + fiNew] = arr[baseOld + fiOld];
+        }
       }
     }
+    arr = out;
+    needsSave = true;
   }
-  await idbPut(this._db, STORE_LAYER, key, out.buffer);
-  await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-  this._layerCache.set(key,out); return out;
+
+  if (storedCount !== qCount) needsSave = true;
+
+  if (needsSave){
+    for (let q=0; q<qCount; q++){
+      const qb = extractQuadrantBuffer(arr, q, qCount, Fnew);
+      await idbPut(this._db, STORE_LAYER, `${key}:${q}`, qb);
+    }
+    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames, quadrantCount:qCount });
+  }
+
+  this._layerCache.set(key, arr); return arr;
 }
 
 export function _mapCellToDense(z, x, y){
@@ -148,7 +173,11 @@ export async function setDenseFromCell(z, xCell, yCell, values){
     this._maxField[name] = Math.max(this._maxField[name]||0, v||0);
     if (name==='O2') this._maxO2=Math.max(this._maxO2, v||0);
   }
-  this._dirtyLayers.add(z|0);
+  const zKey = z|0;
+  const qIdx = quadrantIndexForPixel(bx, by, this.quadrantCount || DEFAULT_QUADRANT_COUNT);
+  let qs = this._dirtyLayers.get(zKey);
+  if (!qs){ qs = new Set(); this._dirtyLayers.set(zKey, qs); }
+  qs.add(qIdx);
   if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 }
 
@@ -164,7 +193,11 @@ export async function addDenseFromCell(z, xCell, yCell, values){
     this._maxField[name] = Math.max(this._maxField[name]||0, nxt);
     if (name==='O2') this._maxO2=Math.max(this._maxO2, nxt);
   }
-  this._dirtyLayers.add(z|0);
+  const zKey = z|0;
+  const qIdx = quadrantIndexForPixel(bx, by, this.quadrantCount || DEFAULT_QUADRANT_COUNT);
+  let qs = this._dirtyLayers.get(zKey);
+  if (!qs){ qs = new Set(); this._dirtyLayers.set(zKey, qs); }
+  qs.add(qIdx);
   if (!this._flushHandle) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 }
 
@@ -179,13 +212,21 @@ export async function sampleDenseForCell(z, xCell, yCell, field){
 export async function _flushDirtyLayers(){
   if (this._disposed){ this._flushHandle=null; return; }
   if (!this._db || !this._dirtyLayers.size){ this._flushHandle=null; return; }
-  const zs=Array.from(this._dirtyLayers);
-  this._dirtyLayers.clear();
-  await Promise.all(zs.map(async z=>{
+  const tasks=[];
+  for (const [z, qs] of this._dirtyLayers){
     const arr=this._layerCache.get(z|0);
-    if (arr) await idbPut(this._db, STORE_LAYER, z|0, arr.buffer);
-    await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
-  }));
+    if (arr){
+      const qCount=this.quadrantCount || DEFAULT_QUADRANT_COUNT;
+      const F=this.schema.fieldNames.length;
+      for (const q of qs){
+        const buf=extractQuadrantBuffer(arr, q, qCount, F);
+        tasks.push(idbPut(this._db, STORE_LAYER, `${z}:${q}`, buf));
+      }
+      tasks.push(idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames, quadrantCount:qCount }));
+    }
+  }
+  this._dirtyLayers.clear();
+  await Promise.all(tasks);
   this._flushHandle=null;
 }
 


### PR DESCRIPTION
## Summary
- Persist overlay layers in quadrant-sized chunks instead of whole-layer buffers
- Track and flush dirty quadrants for granular updates
- Default quadrant count increased to 16 to evenly split 1024x1024 layers

## Testing
- `node --check SDFGridConstants.js`
- `node --check SDFGridCore.js`
- `node --check SDFGridLayers.js`
- `node --check SDFGridQuadrants.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a3fcf0f0832db4f6758360af8faf