### PR TITLE
Store dense layers by quadrant

### DIFF
--- a/SDFGridConstants.js
+++ b/SDFGridConstants.js
@@ -13,4 +13,5 @@ export const STORE_LAYER = 'overlay_layers';
 export const STORE_LMETA = 'overlay_layers_meta';
 
 // Default number of quadrants for environment quantization
-export const DEFAULT_QUADRANT_COUNT = 10;
+// Use 16 to evenly divide the 1024×1024 dense layer into 256×256 quadrants
+export const DEFAULT_QUADRANT_COUNT = 16;

--- a/SDFGridCore.js
+++ b/SDFGridCore.js
@@ -103,7 +103,8 @@ export class SDFGrid{
 
     // caches and batching
     this._layerCache = new Map(); // z -> Float32Array (dense)
-    this._dirtyLayers = new Set();
+    // Track dirty quadrants per layer so updates can persist granularly
+    this._dirtyQuadrants = new Map(); // z -> Set of quadrant indices
     this._flushHandle = null;
 
     // stats

--- a/SDFGridParticles.js
+++ b/SDFGridParticles.js
@@ -46,7 +46,7 @@ export async function updateParticles(particles, dt){
     const vals=Object.fromEntries(this.schema.fieldNames.map(n=>[n,inc]));
     await this.addDenseFromCell(c.z, c.x, c.y, vals);
   }
-  if (!this._flushHandle && this._dirtyLayers.size) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
+  if (!this._flushHandle && this._dirtyQuadrants.size) this._flushHandle=setTimeout(()=>this._flushDirtyLayers(), 200);
 
   this.updateDispersion(dt);
   if (this._disposed || this._rev!==rev) return;

--- a/SDFGridState.js
+++ b/SDFGridState.js
@@ -84,7 +84,7 @@ export async function updateGrid(params){
   { const w=this.state.cellsX,h=this.state.cellsY,dir=params?.propagationDir||{x:1,y:0}; const pick=()=>pickNucleusByDirection(w,h,dir); for(let z=0; z<this.effectiveCellsZ; z++) this._nuclei[z]=pick(); }
 
   this._layerCache.clear();
-  this._dirtyLayers.clear();
+  this._dirtyQuadrants.clear();
   if (this._flushHandle){ clearTimeout(this._flushHandle); this._flushHandle=null; }
 
   this.initializeGrid();
@@ -199,6 +199,6 @@ export function dispose(){
     this.gridGroup=null; this.instancedMesh=null;
   }
   this._layerCache.clear();
-  this._dirtyLayers.clear();
+  this._dirtyQuadrants.clear();
   this.constructor._instances?.delete(this.uid);
 }


### PR DESCRIPTION
## Summary
- Increase default quadrant count to 16 to evenly segment 1024×1024 layers.
- Track dirty quadrants and persist only changed segments per layer.
- Load and flush layer data per quadrant, enabling granular updates.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check SDFGridConstants.js SDFGridCore.js SDFGridLayers.js SDFGridParticles.js SDFGridState.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7abd8bcc0832d9a44fa4e35ce44bd