### PR TITLE
Segment overlay layers into quadrants for granular updates

### DIFF
--- a/SDFGridConstants.js
+++ b/SDFGridConstants.js
@@ -12,5 +12,6 @@ export const STORE_BASEZ = 'base_zero';
 export const STORE_LAYER = 'overlay_layers';
 export const STORE_LMETA = 'overlay_layers_meta';
 
-// Default number of quadrants for environment quantization
-export const DEFAULT_QUADRANT_COUNT = 10;
+// Default number of quadrants for environment quantization and layer storage
+// A 1024×1024 dense layer is divided into 16 quadrants of 256×256 (65,536 cells each)
+export const DEFAULT_QUADRANT_COUNT = 16;

--- a/SDFGridCore.js
+++ b/SDFGridCore.js
@@ -103,7 +103,7 @@ export class SDFGrid{
 
     // caches and batching
     this._layerCache = new Map(); // z -> Float32Array (dense)
-    this._dirtyLayers = new Set();
+    this._dirtyLayers = new Map(); // z -> Set of dirty quadrant indices
     this._flushHandle = null;
 
     // stats


### PR DESCRIPTION
## Summary
- Increase default quadrant count to 16 for 1024x1024 layers
- Track dirty quadrants and store overlay layers per quadrant instead of whole-layer blobs
- Flush and reconstruct layers using individual quadrant buffers

## Testing
- `node --check SDFGridConstants.js SDFGridCore.js SDFGridLayers.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7abd8bcc0832d9a44fa4e35ce44bd