### PR TITLE
Ensure quadrant template valid and guard dense allocations

### DIFF
--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -66,12 +66,44 @@ function _markDirty(ctx, z, bx, by){
   set.add(qi);
 }
 
+function _enqueueLayerTask(ctx, z, fn){
+  ctx._layerTasks ||= new Map();
+  const key=z|0;
+  const prev=ctx._layerTasks.get(key) || Promise.resolve();
+  const next=prev.then(fn);
+  ctx._layerTasks.set(key, next.catch(()=>{}));
+  return next;
+}
+
+function _allocDenseArray(F){
+  const len = DENSE_W * DENSE_H * F;
+  if (!Number.isFinite(len) || len <= 0) return new Float32Array(0);
+  // Avoid unbounded allocations that could exhaust memory when a corrupted
+  // schema reports an extreme field count.
+  if (len > 67_108_864) throw new RangeError('Layer array too large');
+  return new Float32Array(len);
+}
+
+async function _persistQuadrantWithRetry(ctx, z, qi, arr, F, retries=1){
+  if (!ctx._db) return;
+  const keyStr = `${z},${qi}`;
+  let attempt = 0;
+  while (attempt <= retries){
+    const quad = _sliceQuadrant.call(ctx, arr, qi, F);
+    await idbPut(ctx._db, STORE_LAYER, keyStr, quad.buffer);
+    const check = await idbGet(ctx._db, STORE_LAYER, keyStr);
+    if (check) return;
+    attempt++;
+  }
+}
+
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
   if (!this._db) return createSparseQuadrants(count, this.envExpressions || []);
   const key=`sid:${this.schema.id}`;
   let tmpl=await idbGet(this._db, STORE_BASEZ, key);
-  if (!tmpl){
+  const valid = Array.isArray(tmpl?.quadrants) && tmpl.quadrants.length === count;
+  if (!valid){
     tmpl=createSparseQuadrants(count, this.envExpressions || []);
     await idbPut(this._db, STORE_BASEZ, key, tmpl);
   }
@@ -121,11 +153,22 @@ export async function _ensureDenseLayer(z){
 
   const targetSchema=this.schema;
   const Fnew=targetSchema.fieldNames.length;
-  const qCount=this.quadrantCount || DEFAULT_QUADRANT_COUNT;
+
+  // Ensure quadrant count matches the base_zero template so layer
+  // quadrants align with the sparse environment template.  This fixes
+  // situations where the configured quadrantCount differs from what was
+  // persisted in base_zero, leading to missing or misordered layer
+  // quadrant keys.
+  const zeroTmpl = await this._ensureZeroTemplate();
+  const qCount = zeroTmpl.quadrants.length;
+  if (this.quadrantCount !== qCount){
+    this.quadrantCount = qCount;
+    this._quadLayout = null; // force recomputation with new count
+  }
   _ensureLayout(this);
 
   if (!this._db){
-    const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+    const arr=_allocDenseArray(Fnew);
     this._layerCache.set(key,arr); return arr;
   }
 
@@ -133,31 +176,45 @@ export async function _ensureDenseLayer(z){
   const buffers=await Promise.all(Array.from({length:qCount},(_,i)=>idbGet(this._db, STORE_LAYER, `${key},${i}`)));
 
   if (buffers.every(b=>!b)){
-    const tmpl=await this._ensureZeroTemplate();
-    const arr=denseFromQuadrants(tmpl, targetSchema);
+    // No quadrants exist yet for this layer; clone from base_zero template
+    // so each layer begins with the same number of quadrants.
+    const arr=denseFromQuadrants(zeroTmpl, targetSchema);
     await this._applySparseIntoDense(z, arr);
-    await Promise.all(Array.from({length:qCount},(_,i)=>{
-      const quad=_sliceQuadrant.call(this, arr, i, Fnew);
-      return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);
-    }));
-    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+    for(let i=0;i<qCount;i++){
+      await _enqueueLayerTask(this, key, ()=>_persistQuadrantWithRetry(this, key, i, arr, Fnew));
+    }
+    await _enqueueLayerTask(this, key, async()=>{
+      await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+    });
     this._layerCache.set(key,arr); return arr;
   }
 
   const curSid=lmeta?.sid|0;
   const curList=lmeta?.fields || [];
   if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+    const arr=_allocDenseArray(Fnew);
+    const missing=[];
     for(let i=0;i<qCount;i++){
-      const buf=buffers[i]; if(!buf) continue;
-      _insertQuadrant.call(this, arr, i, new Float32Array(buf), Fnew);
+      const buf=buffers[i];
+      if(buf){
+        _insertQuadrant.call(this, arr, i, new Float32Array(buf), Fnew);
+      } else {
+        // Track any absent quadrants so we can persist zeroed versions
+        // to keep layer/quadrant keys in sync with base_zero.
+        missing.push(i);
+      }
+    }
+    if (missing.length){
+      for (const i of missing){
+        await _enqueueLayerTask(this, key, ()=>_persistQuadrantWithRetry(this, key, i, arr, Fnew));
+      }
     }
     this._layerCache.set(key,arr); return arr;
   }
 
   const Fold=curList.length;
   const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-  const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+  const arr=_allocDenseArray(Fnew);
 
   for(let qi=0; qi<qCount; qi++){
     const buf=buffers[qi]; if(!buf) continue;
@@ -183,11 +240,12 @@ export async function _ensureDenseLayer(z){
     }
   }
 
-  await Promise.all(Array.from({length:qCount},(_,i)=>{
-    const quad=_sliceQuadrant.call(this, arr, i, Fnew);
-    return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);
-  }));
-  await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+  for(let i=0;i<qCount;i++){
+    await _enqueueLayerTask(this, key, ()=>_persistQuadrantWithRetry(this, key, i, arr, Fnew));
+  }
+  await _enqueueLayerTask(this, key, async()=>{
+    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+  });
   this._layerCache.set(key,arr); return arr;
 }
 
@@ -273,12 +331,13 @@ export async function _flushDirtyLayers(){
     const arr=this._layerCache.get(z|0);
     if (!arr) return;
     const F=this.schema.fieldNames.length;
-    const writes=Array.from(set).map(qi=>{
-      const quad=_sliceQuadrant.call(this, arr, qi, F);
-      return idbPut(this._db, STORE_LAYER, `${z},${qi}`, quad.buffer);
+    const ordered=Array.from(set).sort((a,b)=>a-b);
+    for (const qi of ordered){
+      await _enqueueLayerTask(this, z, ()=>_persistQuadrantWithRetry(this, z, qi, arr, F));
+    }
+    await _enqueueLayerTask(this, z, async()=>{
+      await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
     });
-    writes.push(idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames }));
-    await Promise.all(writes);
   }));
   this._flushHandle=null;
 }


### PR DESCRIPTION
## Summary
- Rebuild `base_zero` template when stored quadrant count is invalid
- Add `_allocDenseArray` to bound dense layer size and reuse for allocations

## Testing
- `node --check SDFGridLayers.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c8c82284832d8329da5184b96e71