### PR TITLE
Ensure sequential layer quadrant persistence reliability

### DIFF
--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -1,7 +1,48 @@
 import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import { arraysEqual } from './SDFGridUtil.js';
-import { idbGet, idbPut } from './SDFGridStorage.js';
+import { idbGet, idbPut, idbDelete } from './SDFGridStorage.js';
 import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js';
+
+const QUADRANT_WRITE_ATTEMPTS = 3;
+
+function _normalizeQuadrantCount(ctx, desired){
+  const current=Number.isFinite(ctx.quadrantCount) && ctx.quadrantCount>0 ? ctx.quadrantCount|0 : DEFAULT_QUADRANT_COUNT;
+  let next=Number.isFinite(desired) && desired>0 ? desired|0 : current;
+  if (!Number.isFinite(next) || next<=0) next=DEFAULT_QUADRANT_COUNT;
+  if (ctx.quadrantCount !== next){
+    ctx.quadrantCount = next;
+    ctx._quadLayout = null;
+    ctx._quadKeyWidth = null;
+  }
+  return ctx.quadrantCount || DEFAULT_QUADRANT_COUNT;
+}
+
+function _quadrantKeyWidth(ctx){
+  if (ctx._quadKeyWidth) return ctx._quadKeyWidth;
+  const qCount=ctx.quadrantCount || DEFAULT_QUADRANT_COUNT;
+  const maxIndex=Math.max(0, qCount-1);
+  const width=Math.max(1, String(maxIndex).length);
+  ctx._quadKeyWidth = width;
+  return width;
+}
+
+function _layerQuadrantKey(ctx, z, qi){
+  const width=_quadrantKeyWidth(ctx);
+  const layer=z|0;
+  const idx=Math.max(0, qi|0);
+  return `${layer},${idx.toString().padStart(width,'0')}`;
+}
+
+async function _getStoredQuadrant(ctx, z, qi){
+  if (!ctx._db) return { buffer:null, legacyKey:null };
+  const primaryKey=_layerQuadrantKey(ctx, z, qi);
+  let buf=await idbGet(ctx._db, STORE_LAYER, primaryKey);
+  if (buf) return { buffer:buf, legacyKey:null };
+  const legacyKey=`${z|0},${qi|0}`;
+  if (legacyKey===primaryKey) return { buffer:null, legacyKey:null };
+  buf=await idbGet(ctx._db, STORE_LAYER, legacyKey);
+  return { buffer:buf, legacyKey:buf ? legacyKey : null };
+}
 
 function _quadrantLayout(count){
   const cols=Math.ceil(Math.sqrt(count));
@@ -56,6 +97,36 @@ function _insertQuadrant(arr, qi, quad, F){
       const base=rowBase + x*F;
       for(let fi=0;fi<F;fi++) arr[base+fi]=quad[idx++];
     }
+  }
+}
+
+async function _writeQuadrantWithRetry(ctx, z, qi, arr, F){
+  if (!ctx._db) return;
+  const key=_layerQuadrantKey(ctx, z, qi);
+  for (let attempt=0; attempt<QUADRANT_WRITE_ATTEMPTS; attempt++){
+    const quad=_sliceQuadrant.call(ctx, arr, qi, F);
+    const expectedBytes=quad.byteLength;
+    await idbPut(ctx._db, STORE_LAYER, key, quad.buffer);
+    const stored=await idbGet(ctx._db, STORE_LAYER, key);
+    const storedBytes=stored instanceof ArrayBuffer ? stored.byteLength : (stored?.byteLength ?? stored?.buffer?.byteLength ?? 0);
+    if (storedBytes === expectedBytes) return;
+  }
+  throw new Error(`Failed to persist quadrant ${key} after ${QUADRANT_WRITE_ATTEMPTS} attempts`);
+}
+
+async function _storeQuadrantsSequential(ctx, z, arr, F, indices){
+  if (!ctx._db) return;
+  _ensureLayout(ctx);
+  const qCount=ctx.quadrantCount || DEFAULT_QUADRANT_COUNT;
+  const baseList=indices ? Array.from(indices) : Array.from({length:qCount},(_,i)=>i);
+  const list=baseList.filter(i=>Number.isFinite(i) && i>=0 && i<qCount);
+  if (!list.length) return;
+  list.sort((a,b)=>a-b);
+  let prev=-1;
+  for (const qi of list){
+    if (qi===prev) continue;
+    prev=qi;
+    await _writeQuadrantWithRetry(ctx, z, qi, arr, F);
   }
 }
 
@@ -116,53 +187,81 @@ export function _denseIdx(F,xPix,yPix,fi){
 }
 
 export async function _ensureDenseLayer(z){
-  const key=z|0;
-  if (this._layerCache.has(key)) return this._layerCache.get(key);
+  const layer=z|0;
+  if (this._layerCache.has(layer)) return this._layerCache.get(layer);
 
   const targetSchema=this.schema;
   const Fnew=targetSchema.fieldNames.length;
-  const qCount=this.quadrantCount || DEFAULT_QUADRANT_COUNT;
-  _ensureLayout(this);
 
   if (!this._db){
     const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
-    this._layerCache.set(key,arr); return arr;
+    this._layerCache.set(layer,arr); return arr;
   }
 
-  const lmeta=await idbGet(this._db, STORE_LMETA, key);
-  const buffers=await Promise.all(Array.from({length:qCount},(_,i)=>idbGet(this._db, STORE_LAYER, `${key},${i}`)));
+  const tmpl=await this._ensureZeroTemplate();
+  const tmplCount=Array.isArray(tmpl?.quadrants) ? tmpl.quadrants.length : 0;
+  const qCount=_normalizeQuadrantCount(this, tmplCount || this.quadrantCount || DEFAULT_QUADRANT_COUNT);
+  _ensureLayout(this);
 
-  if (buffers.every(b=>!b)){
-    const tmpl=await this._ensureZeroTemplate();
+  const lmeta=await idbGet(this._db, STORE_LMETA, layer);
+  const buffers=new Array(qCount);
+  const missing=[];
+  const legacyIndices=[];
+  const legacyDeleteKeys=[];
+  for(let i=0;i<qCount;i++){
+    const { buffer, legacyKey } = await _getStoredQuadrant(this, layer, i);
+    buffers[i]=buffer;
+    if (!buffer) missing.push(i);
+    if (legacyKey){
+      legacyIndices.push(i);
+      legacyDeleteKeys.push(legacyKey);
+    }
+  }
+
+  const allMissing=missing.length===qCount;
+
+  if (allMissing){
     const arr=denseFromQuadrants(tmpl, targetSchema);
     await this._applySparseIntoDense(z, arr);
-    await Promise.all(Array.from({length:qCount},(_,i)=>{
-      const quad=_sliceQuadrant.call(this, arr, i, Fnew);
-      return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);
-    }));
-    await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-    this._layerCache.set(key,arr); return arr;
+    await _storeQuadrantsSequential(this, layer, arr, Fnew);
+    await idbPut(this._db, STORE_LMETA, layer, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+    if (legacyDeleteKeys.length){
+      const deleteKeys=Array.from(new Set(legacyDeleteKeys));
+      await Promise.all(deleteKeys.map(key=>idbDelete(this._db, STORE_LAYER, key)));
+    }
+    this._layerCache.set(layer,arr); return arr;
   }
 
   const curSid=lmeta?.sid|0;
   const curList=lmeta?.fields || [];
   if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+    const needTemplate=missing.length || legacyIndices.length;
+    const arr=needTemplate ? denseFromQuadrants(tmpl, targetSchema) : new Float32Array(DENSE_W*DENSE_H*Fnew);
     for(let i=0;i<qCount;i++){
       const buf=buffers[i]; if(!buf) continue;
       _insertQuadrant.call(this, arr, i, new Float32Array(buf), Fnew);
     }
-    this._layerCache.set(key,arr); return arr;
+    if (needTemplate){
+      const rewrite=new Set([...missing, ...legacyIndices]);
+      if (missing.length) await this._applySparseIntoDense(z, arr);
+      await _storeQuadrantsSequential(this, layer, arr, Fnew, rewrite);
+      await idbPut(this._db, STORE_LMETA, layer, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+      if (legacyDeleteKeys.length){
+        const deleteKeys=Array.from(new Set(legacyDeleteKeys));
+        await Promise.all(deleteKeys.map(key=>idbDelete(this._db, STORE_LAYER, key)));
+      }
+    }
+    this._layerCache.set(layer,arr); return arr;
   }
 
   const Fold=curList.length;
   const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-  const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+  const arr=denseFromQuadrants(tmpl, targetSchema);
+  const { cols, qW, qH } = _ensureLayout(this);
 
   for(let qi=0; qi<qCount; qi++){
     const buf=buffers[qi]; if(!buf) continue;
     const quadOld=new Float32Array(buf);
-    const { cols, qW, qH } = this._quadLayout;
     const col=qi%cols, row=Math.floor(qi/cols);
     const xStart=col*qW, yStart=row*qH;
     const xEnd=Math.min(xStart+qW, DENSE_W);
@@ -183,12 +282,13 @@ export async function _ensureDenseLayer(z){
     }
   }
 
-  await Promise.all(Array.from({length:qCount},(_,i)=>{
-    const quad=_sliceQuadrant.call(this, arr, i, Fnew);
-    return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);
-  }));
-  await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
-  this._layerCache.set(key,arr); return arr;
+  await _storeQuadrantsSequential(this, layer, arr, Fnew);
+  await idbPut(this._db, STORE_LMETA, layer, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+  if (legacyDeleteKeys.length){
+    const deleteKeys=Array.from(new Set(legacyDeleteKeys));
+    await Promise.all(deleteKeys.map(key=>idbDelete(this._db, STORE_LAYER, key)));
+  }
+  this._layerCache.set(layer,arr); return arr;
 }
 
 export function _mapCellToDense(z, x, y){
@@ -273,12 +373,11 @@ export async function _flushDirtyLayers(){
     const arr=this._layerCache.get(z|0);
     if (!arr) return;
     const F=this.schema.fieldNames.length;
-    const writes=Array.from(set).map(qi=>{
-      const quad=_sliceQuadrant.call(this, arr, qi, F);
-      return idbPut(this._db, STORE_LAYER, `${z},${qi}`, quad.buffer);
-    });
-    writes.push(idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames }));
-    await Promise.all(writes);
+    const indices=Array.from(set);
+    if (indices.length){
+      await _storeQuadrantsSequential(this, z|0, arr, F, indices);
+    }
+    await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
   }));
   this._flushHandle=null;
 }

--- a/SDFGridStorage.js
+++ b/SDFGridStorage.js
@@ -35,3 +35,10 @@ export function idbPut(db,store,key,val){
     const rq=st.put(val,key); rq.onsuccess=()=>res(true); rq.onerror=()=>rej(rq.error);
   });
 }
+
+export function idbDelete(db,store,key){
+  return new Promise((res,rej)=>{
+    const tx=db.transaction(store,'readwrite'), st=tx.objectStore(store);
+    const rq=st.delete(key); rq.onsuccess=()=>res(true); rq.onerror=()=>rej(rq.error);
+  });
+}


### PR DESCRIPTION
## Summary
- normalize layer quadrant counts against the base template and build retrying helpers to persist quadrants sequentially
- rewrite `_ensureDenseLayer` to verify stored quadrants, recover missing legacy data, and flush dirty quadrants using the new helpers
- add an IndexedDB delete helper to clean up obsolete quadrant entries

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c839ad3088832d98e11cae5febabcd